### PR TITLE
Fix/sistema armas

### DIFF
--- a/common/game_info/bullet_info.cpp
+++ b/common/game_info/bullet_info.cpp
@@ -3,8 +3,8 @@
 #include <stdexcept>
 
 BulletInfo::BulletInfo(const ServerEntityID id, const Weapon weapon, const float pos_x,
-                       const float pos_y, const Vec2D& direction):
-        id(id), weapon(weapon), pos_x(pos_x), pos_y(pos_y), direction(direction) {}
+                       const float pos_y, const Vec2D& direction, bool active):
+        id(id), weapon(weapon), pos_x(pos_x), pos_y(pos_y), direction(direction), active(active) {}
 
 BulletInfo::BulletInfo(const std::vector<uint8_t>& bytes) {
     // Chequear el size y lanzar excepcion
@@ -25,6 +25,9 @@ BulletInfo::BulletInfo(const std::vector<uint8_t>& bytes) {
     // Direction (3 bytes cada componente)
     direction.setX(Protocol_::getFloatNormalized(bytes[13], bytes[14], bytes[15]));
     direction.setY(Protocol_::getFloatNormalized(bytes[16], bytes[17], bytes[18]));
+
+    // Active (1 byte)
+    active = Protocol_::decodeBool(bytes[19]);
 }
 
 std::vector<uint8_t> BulletInfo::toBytes() const {
@@ -44,6 +47,9 @@ std::vector<uint8_t> BulletInfo::toBytes() const {
     Protocol_::insertFloatNormalized3Bytes(direction.getX(), buffer);
     Protocol_::insertFloatNormalized3Bytes(direction.getY(), buffer);
 
+    // Active (1 byte)
+    buffer.push_back(Protocol_::encodeBool(active));
+
     return buffer;
 }
 
@@ -52,7 +58,7 @@ void BulletInfo::print() const {
               << "id=" << id << ", weapon=" << static_cast<int>(weapon) << ", pos=(" << pos_x
               << ", " << pos_y << ")"
               << ", dir=(" << direction.getX() << ", " << direction.getY() << ")"
-              << " }\n";
+              << ", active=" << (active ? "true" : "false") << " }\n";
 }
 
 SpriteType BulletInfo::getSpriteType() { return SpriteType::BULLET; }

--- a/common/game_info/bullet_info.h
+++ b/common/game_info/bullet_info.h
@@ -7,7 +7,7 @@
 #include "..//types.h"
 #include "../protocol.h"
 
-#define SIZE_BULLET_INFO 19
+#define SIZE_BULLET_INFO 20
 
 struct BulletInfo {
     ServerEntityID id;  // server_entt_id
@@ -16,9 +16,10 @@ struct BulletInfo {
     float pos_x;
     float pos_y;
     Vec2D direction;
+    bool active;
 
     BulletInfo() = default;
-    BulletInfo(ServerEntityID id, Weapon weapon, float pos_x, float pos_y, const Vec2D& direction);
+    BulletInfo(ServerEntityID id, Weapon weapon, float pos_x, float pos_y, const Vec2D& direction, bool active = true);
 
     BulletInfo(const BulletInfo& other) = default;
     BulletInfo& operator=(const BulletInfo& other) = default;

--- a/common/game_info/game_info.cpp
+++ b/common/game_info/game_info.cpp
@@ -95,7 +95,7 @@ GameInfo::GameInfo(const std::vector<uint8_t>& bytes) {
         BulletInfo b(bulletBytes);
         bullets.emplace_back(b);
         EntitySnapshot entity(b.id, EntityType::BULLET, SpriteType::BULLET, b.pos_x, b.pos_y,
-                              b.direction.calculateAngleDegrees(), true);
+                              b.direction.calculateAngleDegrees(), b.active);
         entities.emplace_back(entity);
 
         index += SIZE_BULLET_INFO;

--- a/server/config.YAML
+++ b/server/config.YAML
@@ -18,18 +18,24 @@ weapons:
     damage: 35 # daño por bala
     price: 2700 # precio del arma
     bullets: 30
-    rate_of_fire: 24 
+    rate_of_fire: 24
+    precision: 0.8
+    max_range: 700
 
   awp:
     damage: 100 # daño por disparo
     price: 3500 # precio del arma
     bullets: 10
     rate_of_fire: 20
+    precision: 1
+    max_range: 1000
 
   glock:
     damage: 45 # daño por bala
     bullets: 40
-    rate_of_fire: 700 
+    rate_of_fire: 700
+    precision: 0.8
+    max_range: 600
 
   knife:
     damage: 20 # daño del cuchillo
@@ -39,6 +45,8 @@ weapons:
     price: 3000 # precio del arma
     bullets: 20
     rate_of_fire: 60
+    precision: 0.5
+    max_range: 400
 
 bomb:
   time_to_explode: 15 # tiempo hasta que explota (en segundos)

--- a/server/include/match.h
+++ b/server/include/match.h
@@ -68,6 +68,7 @@ private:
     // void processActionMatch(Player* player, const GameAction &gameAction, const float deltaTime);
     void handleKnifeAttack(Player* attacker, const Vec2D& direction);
     void setPosSpawnPlayer(Player& p);
+    bool isFriendlyFire(const std::string& shooterId, Team targetTeam) const;
 
 
     // CONSTANTES static para inicializar en server.cpp.

--- a/server/include/physics_engine.h
+++ b/server/include/physics_engine.h
@@ -4,6 +4,7 @@
 #include <cmath>
 #include <memory>
 #include <vector>
+#include <random>
 
 #include "map.h"
 #include "player.h"
@@ -13,7 +14,7 @@
 class PhysicsEngine {
 public:
     static void movePlayer(Player& player, float dirX, float dirY, float deltaTime, Map& map);
-    static bool shotHitPlayer(float projX, float projY, const Player& target, float& impactDistance);
+    static bool shotHitPlayer(float projX, float projY, const Player& target, const FireWeapon& weapon, float& impactDistance);
     static float calculatePrecisionByDistance(float distance, float maxRange, float basePrecision);
     static bool knifeHit(float originX, float originY, float dirX, float dirY, const Player& target,
                          float& outDist);

--- a/server/include/physics_engine.h
+++ b/server/include/physics_engine.h
@@ -13,8 +13,7 @@
 class PhysicsEngine {
 public:
     static void movePlayer(Player& player, float dirX, float dirY, float deltaTime, Map& map);
-    static bool shotHitPlayer(float originX, float originY, float dirX, float dirY, Map& map,
-                              const Player& target, float maxDistance, float& impactDistance);
+    static bool shotHitPlayer(float projX, float projY, const Player& target, float& impactDistance);
     static float calculatePrecisionByDistance(float distance, float maxRange, float basePrecision);
     static bool knifeHit(float originX, float originY, float dirX, float dirY, const Player& target,
                          float& outDist);

--- a/server/include/weapon/fire_weapon.h
+++ b/server/include/weapon/fire_weapon.h
@@ -12,9 +12,11 @@ protected:
     int bullets;
     int rateOfFire;
     double lastShotTimeS;
+    float basePrecision;
+    float maxRange;
 
 public:
-    FireWeapon(int damage, float price, int bullets, int rateOfFire);
+    FireWeapon(int damage, float price, int bullets, int rateOfFire, float basePrecision, float maxRange);
     ~FireWeapon() override = default;
 
     bool canShoot(double currentTime) const override;
@@ -22,6 +24,9 @@ public:
 
     void addBullets(int amount);
     int getBullets() const override;
+
+    float getBasePrecision() const;
+    float getMaxRange() const;
 };
 
 #endif

--- a/server/include/weapon/weapon_ak47.h
+++ b/server/include/weapon/weapon_ak47.h
@@ -24,10 +24,12 @@ private:
     static float PRICE;
     static int INITIAL_BULLETS;
     static int RATE_OF_FIRE;
+    static float PRECISION;
+    static float MAX_RANGE;
 
 public:
     // Para cargar los valores del config.yaml
-    static void init(int damage, float price, int bullets, int rate_of_fire);
+    static void init(int damage, float price, int bullets, int rate_of_fire, float precision, float max_range);
 };
 
 #endif

--- a/server/include/weapon/weapon_awp.h
+++ b/server/include/weapon/weapon_awp.h
@@ -24,10 +24,12 @@ private:
     static float PRICE;
     static int INITIAL_BULLETS;
     static int RATE_OF_FIRE;
+    static float PRECISION;
+    static float MAX_RANGE;
 
 public:
     // Para cargar los valores del config.yaml
-    static void init(int damage, float price, int bullets, int rate_of_fire);
+    static void init(int damage, float price, int bullets, int rate_of_fire, float precision, float max_range);
 };
 
 #endif

--- a/server/include/weapon/weapon_glock.h
+++ b/server/include/weapon/weapon_glock.h
@@ -23,10 +23,12 @@ private:
     static int DAMAGE;
     static int INITIAL_BULLETS;
     static int RATE_OF_FIRE;
+    static float PRECISION;
+    static float MAX_RANGE;
 
 public:
     // Para cargar los valores del config.yaml
-    static void init(int damage, int bullets, int rate_of_fire);
+    static void init(int damage, int bullets, int rate_of_fire, float precision, float max_range);
 };
 
 #endif

--- a/server/include/weapon/weapon_m3.h
+++ b/server/include/weapon/weapon_m3.h
@@ -25,10 +25,12 @@ private:
     static float PRICE;
     static int INITIAL_BULLETS;
     static int RATE_OF_FIRE;
+    static float PRECISION;
+    static float MAX_RANGE;
 
 public:
     // Para cargar los valores del config.yaml
-    static void init(int damage, float price, int bullets, int rate_of_fire);
+    static void init(int damage, float price, int bullets, int rate_of_fire, float precision, float max_range);
 };
 
 #endif

--- a/server/include/yaml_config.h
+++ b/server/include/yaml_config.h
@@ -28,6 +28,8 @@ public:
         int price = 0;
         int bullets;
         int rateOfFire;
+        float precision;
+        float maxRange;
     };
 
     WeaponData getWeaponData(const std::string& weaponName) const;

--- a/server/src/match.cpp
+++ b/server/src/match.cpp
@@ -208,8 +208,7 @@ void Match::updateState(double elapsedTime) {
     projectiles.erase(std::remove_if(projectiles.begin(), projectiles.end(),
                                      [](const Projectile& p) { return !p.isActive(); }),
                       projectiles.end());
-    // std::cout << "UpdateState " << roundTimer << " : Juego en fase " << (phase ==
-    // GamePhase::Preparation ? "Preparation " : "Combate ") << std::endl;
+
     if (roundOver)
         return;
     current_time += elapsedTime;
@@ -246,8 +245,11 @@ void Match::updateState(double elapsedTime) {
                 continue;
 
             float impactDist;
-            if (PhysicsEngine::shotHitPlayer(proj.getX(), proj.getY(), target, impactDist)) {
-                const std::unique_ptr<Weapon_> weapon = WeaponFactory::create(proj.getWeaponUsed());
+            //const std::unique_ptr<Weapon_> weapon = WeaponFactory::create(proj.getWeaponUsed());
+            const std::unique_ptr<Weapon_> rawWeapon = WeaponFactory::create(proj.getWeaponUsed());
+            auto* weapon = dynamic_cast<FireWeapon*>(rawWeapon.get());
+            if (!weapon) continue;
+            if (PhysicsEngine::shotHitPlayer(proj.getX(), proj.getY(), target, *weapon, impactDist)) {
 
                 if (!isFriendlyFire(proj.getShooter(), target.getTeam())) {
                     target.takeDamage(weapon->getDamage());

--- a/server/src/match.cpp
+++ b/server/src/match.cpp
@@ -85,8 +85,6 @@ bool Match::movePlayer(const std::string& playerName, const float dx, const floa
         return false;
 
     try {
-        std::cout << "En match::movePlayer llega con los parametros: (" << dx << ", " << dy
-                  << "), y deltatime: " << deltaTime << std::endl;
         PhysicsEngine::movePlayer(*p, dx, dy, deltaTime, map);
         return true;
     } catch (...) {
@@ -185,7 +183,7 @@ void Match::processAction(const PlayerAction& action, const float deltaTime) {
                 return;
             }
             case GameActionType::Rotate: {
-                std::cout << "recibí rotar" << std::endl;
+                //std::cout << "recibí rotar" << std::endl;
                 player->setAngle(action.gameAction.angle);
                 break;
             }
@@ -205,6 +203,11 @@ void Match::processAction(const PlayerAction& action, const float deltaTime) {
 }
 
 void Match::updateState(double elapsedTime) {
+
+    // Eliminamos proyectiles inactivos
+    projectiles.erase(std::remove_if(projectiles.begin(), projectiles.end(),
+                                     [](const Projectile& p) { return !p.isActive(); }),
+                      projectiles.end());
     // std::cout << "UpdateState " << roundTimer << " : Juego en fase " << (phase ==
     // GamePhase::Preparation ? "Preparation " : "Combate ") << std::endl;
     if (roundOver)
@@ -243,11 +246,12 @@ void Match::updateState(double elapsedTime) {
                 continue;
 
             float impactDist;
-            if (PhysicsEngine::shotHitPlayer(proj.getX(), proj.getY(), proj.getDirX(),
-                                             proj.getDirY(), map, target, proj.getMaxDistance(),
-                                             impactDist)) {
+            if (PhysicsEngine::shotHitPlayer(proj.getX(), proj.getY(), target, impactDist)) {
                 const std::unique_ptr<Weapon_> weapon = WeaponFactory::create(proj.getWeaponUsed());
-                target.takeDamage(weapon->getDamage());
+
+                if (!isFriendlyFire(proj.getShooter(), target.getTeam())) {
+                    target.takeDamage(weapon->getDamage());
+                }
 
                 if (!target.isAlive()) {
                     std::unique_ptr<Weapon_> droppedWeapon = target.dropPrimaryWeapon();
@@ -269,11 +273,6 @@ void Match::updateState(double elapsedTime) {
             proj.deactivate();
         }
     }
-
-    // Eliminamos proyectiles inactivos
-    projectiles.erase(std::remove_if(projectiles.begin(), projectiles.end(),
-                                     [](const Projectile& p) { return !p.isActive(); }),
-                      projectiles.end());
 
     checkRoundEnd();
 
@@ -396,7 +395,7 @@ GameInfo Match::generateGameInfo(const std::string& username) const {
     // cargo bullets
     for (auto& p: projectiles) {
         bulletsInfo.emplace_back(p.getServerId(), p.getWeaponUsed(), p.getX(), p.getY(),
-                                 Vec2D(p.getDirX(), p.getDirY()));
+                                 Vec2D(p.getDirX(), p.getDirY()), p.isActive());
     }
     // cargo drops
     for (auto& droppedWeapon: droppedWeapons) {
@@ -427,7 +426,8 @@ void Match::handleKnifeAttack(Player* attacker, const Vec2D& direction) {
 
         float impactDistance;
         if (PhysicsEngine::knifeHit(attacker->getX(), attacker->getY(), direction.getX(),
-                                    direction.getY(), target, impactDistance)) {
+                                    direction.getY(), target, impactDistance) &&
+                                    !isFriendlyFire(attacker->getId(), target.getTeam())) {
             target.takeDamage(20);
         }
     }
@@ -492,6 +492,7 @@ void Match::advancePhase() {
         // Pasar a la fase de preparacion
         roundTimer = PREPARATION_TIME;
         phase = GamePhase::Preparation;
+        roundOver = false;
     }
 }
 
@@ -505,3 +506,19 @@ void Match::setPosSpawnPlayer(Player& p) {
         p.setPostion(map.getPositionCTZone());
     }
 }
+
+bool Match::isFriendlyFire(const std::string &shooterId, Team targetTeam) const {
+    auto it = std::find_if(players.begin(), players.end(),
+                            [&shooterId](const Player& p) {
+                               return p.getId() == shooterId;
+                            });
+
+    if (it == players.end()) {
+        std::cout << "Shooter ID no encontrado: " << shooterId << "\n";
+        return true;
+    }
+
+    const Player& shooter = *it;
+    return shooter.getTeam() == targetTeam;
+}
+

--- a/server/src/physics_engine.cpp
+++ b/server/src/physics_engine.cpp
@@ -33,7 +33,10 @@ void PhysicsEngine::movePlayer(Player& player, float dirX, float dirY, float del
 
 
 bool PhysicsEngine::shotHitPlayer(float projX, float projY,
-                                  const Player& target, float& impactDistance) {
+                                  const Player& target, const FireWeapon& weapon, float& impactDistance) {
+    static std::default_random_engine rng(std::random_device{}());
+    static std::uniform_real_distribution<float> dist(0.0f, 1.0f);
+
     float dx = target.getX() - projX;
     float dy = target.getY() - projY;
 
@@ -42,7 +45,17 @@ bool PhysicsEngine::shotHitPlayer(float projX, float projY,
 
     if (distance < targetRadius) {
         impactDistance = distance;
-        return true;
+
+        float precision = calculatePrecisionByDistance(distance, weapon.getMaxRange(), weapon.getBasePrecision());
+        float roll = dist(rng);
+
+        if (roll <= precision) {
+            std::cout << "Disparo ACERTADO - precision: " << precision << ", roll: " << roll << std::endl;
+            return true;
+        } else {
+            std::cout << "Disparo FALLADO - precision: " << precision << ", roll: " << roll << std::endl;
+            return false;
+        }
     }
 
     return false;

--- a/server/src/physics_engine.cpp
+++ b/server/src/physics_engine.cpp
@@ -31,40 +31,18 @@ void PhysicsEngine::movePlayer(Player& player, float dirX, float dirY, float del
     }
 }
 
-bool PhysicsEngine::shotHitPlayer(float originX, float originY, float dirX, float dirY, Map& map,
-                                  const Player& target, float maxDistance, float& impactDistance) {
-    // Normalizar la dirección
-    const float len = std::sqrt(dirX * dirX + dirY * dirY);
-    if (len == 0.0f)
-        return false;
-    dirX /= len;
-    dirY /= len;
 
-    float stepSize = 0.1f;
-    float x = originX;
-    float y = originY;
-    float distance = 0.0f;
+bool PhysicsEngine::shotHitPlayer(float projX, float projY,
+                                  const Player& target, float& impactDistance) {
+    float dx = target.getX() - projX;
+    float dy = target.getY() - projY;
 
+    float distance = std::sqrt(dx * dx + dy * dy);
     float targetRadius = 15.0f;
 
-    while (distance < maxDistance) {
-        // verificamos colision con el mapa
-        if (!map.isWalkable(static_cast<int>(x), static_cast<int>(y))) {
-            return false;
-        }
-
-        const float dx = target.getX() - x;
-        const float dy = target.getY() - y;
-        float distToTarget = std::sqrt(dx * dx + dy * dy);
-
-        if (distToTarget < targetRadius) {  // radio del hitbox
-            impactDistance = distance;
-            return true;
-        }
-
-        x += dirX * stepSize;
-        y += dirY * stepSize;
-        distance += stepSize;
+    if (distance < targetRadius) {
+        impactDistance = distance;
+        return true;
     }
 
     return false;

--- a/server/src/server.cpp
+++ b/server/src/server.cpp
@@ -53,16 +53,16 @@ void Server::initConstants(const YamlConfig& yamlConfig) const {
 
     // weapons.
     auto ak47 = yamlConfig.getWeaponData("ak47");
-    WeaponAk47::init(ak47.damage, ak47.price, ak47.bullets, ak47.rateOfFire);
+    WeaponAk47::init(ak47.damage, ak47.price, ak47.bullets, ak47.rateOfFire, ak47.precision, ak47.maxRange);
 
     auto awp = yamlConfig.getWeaponData("awp");
-    WeaponAwp::init(awp.damage, awp.price, awp.bullets, awp.rateOfFire);
+    WeaponAwp::init(awp.damage, awp.price, awp.bullets, awp.rateOfFire, awp.precision, awp.maxRange);
 
     auto m3 = yamlConfig.getWeaponData("m3");
-    WeaponM3::init(m3.damage, m3.price, m3.bullets, m3.rateOfFire);
+    WeaponM3::init(m3.damage, m3.price, m3.bullets, m3.rateOfFire, m3.precision, m3.maxRange);
 
     auto glock = yamlConfig.getWeaponData("glock");
-    WeaponGlock::init(glock.damage, glock.bullets, glock.rateOfFire);
+    WeaponGlock::init(glock.damage, glock.bullets, glock.rateOfFire, glock.precision, glock.maxRange);
 
     auto knife = yamlConfig.getWeaponData("knife");
     WeaponKnife::init(knife.damage);

--- a/server/src/weapon/fire_weapon.cpp
+++ b/server/src/weapon/fire_weapon.cpp
@@ -2,8 +2,9 @@
 
 #include <iostream>
 
-FireWeapon::FireWeapon(int damage, float price, int bullets, int rateOfFire):
-        Weapon_(damage), price(price), bullets(bullets), rateOfFire(rateOfFire), lastShotTimeS(0) {}
+FireWeapon::FireWeapon(int damage, float price, int bullets, int rateOfFire, float basePrecision, float maxRange):
+        Weapon_(damage), price(price), bullets(bullets), rateOfFire(rateOfFire),
+        lastShotTimeS(0), basePrecision(basePrecision), maxRange(maxRange) {}
 
 
 bool FireWeapon::canShoot(double currentTime) const {
@@ -22,3 +23,8 @@ double FireWeapon::getCooldownS() const {
 void FireWeapon::addBullets(int amount) { bullets += amount; }
 
 int FireWeapon::getBullets() const { return bullets; }
+
+float FireWeapon::getBasePrecision() const { return basePrecision; }
+
+float FireWeapon::getMaxRange() const { return maxRange; }
+

--- a/server/src/weapon/weapon_ak47.cpp
+++ b/server/src/weapon/weapon_ak47.cpp
@@ -2,6 +2,8 @@
 
 #include <complex>
 
+#include "yaml-cpp/emittermanip.h"
+
 //-------------
 // Inicializo las variables estáticas (para poder compilar)
 bool WeaponAk47::initialized = false;
@@ -9,20 +11,24 @@ int WeaponAk47::DAMAGE = 0;
 float WeaponAk47::PRICE = 0;
 int WeaponAk47::INITIAL_BULLETS = 0;
 int WeaponAk47::RATE_OF_FIRE = 0;
+float WeaponAk47::PRECISION = 0;
+float WeaponAk47::MAX_RANGE = 0;
 
 
-void WeaponAk47::init(int damage, float price, int bullets, int rate_of_fire) {
+void WeaponAk47::init(int damage, float price, int bullets, int rate_of_fire, float precision, float max_range) {
     if (initialized == false) {
         DAMAGE = damage;
         PRICE = price;
         INITIAL_BULLETS = bullets;
         RATE_OF_FIRE = rate_of_fire;
+        PRECISION = precision;
+        MAX_RANGE = max_range;
         initialized = true;
     }
 }
 //------------
 
-WeaponAk47::WeaponAk47(): FireWeapon(DAMAGE, PRICE, INITIAL_BULLETS, RATE_OF_FIRE) {}
+WeaponAk47::WeaponAk47(): FireWeapon(DAMAGE, PRICE, INITIAL_BULLETS, RATE_OF_FIRE, PRECISION, MAX_RANGE) {}
 
 Weapon WeaponAk47::getWeaponType() const { return Weapon::Ak47; }
 

--- a/server/src/weapon/weapon_ak47.cpp
+++ b/server/src/weapon/weapon_ak47.cpp
@@ -1,5 +1,7 @@
 #include "../../include/weapon/weapon_ak47.h"
 
+#include <complex>
+
 //-------------
 // Inicializo las variables estáticas (para poder compilar)
 bool WeaponAk47::initialized = false;
@@ -40,8 +42,26 @@ std::vector<Projectile> WeaponAk47::shoot(float posX, float posY, float dirX, fl
     bullets -= bulletsToShoot;
 
     std::vector<Projectile> projectiles;
+
+    // Normalizamos el vector perpendicular
+    float length = std::sqrt(dirX * dirX + dirY * dirY);
+    float normDirX = dirX;
+    float normDirY = dirY;
+    if (length != 0) {
+        normDirX /= length;
+        normDirY /= length;
+    }
+
+    // Offset entre proyectiles de la rafaga
+    float offset = 12.0f;
+
     for (int i = 0; i < bulletsToShoot; ++i) {
-        Projectile p(posX, posY, dirX, dirY, 450.0f, 900.0f, shooter, Weapon::Ak47);
+        float offsetFactor = i * offset;
+        float spawnX = posX - normDirX * offsetFactor;
+        float spawnY = posY - normDirY * offsetFactor;
+
+        //Projectile p(posX, posY, dirX, dirY, 450.0f, 900.0f, shooter, Weapon::Ak47);
+        Projectile p(spawnX, spawnY, dirX, dirY, 450.0f, 900.0f, shooter, Weapon::Ak47);
         projectiles.push_back(p);
     }
 

--- a/server/src/weapon/weapon_awp.cpp
+++ b/server/src/weapon/weapon_awp.cpp
@@ -7,20 +7,24 @@ int WeaponAwp::DAMAGE = 0;
 float WeaponAwp::PRICE = 0;
 int WeaponAwp::INITIAL_BULLETS = 0;
 int WeaponAwp::RATE_OF_FIRE = 0;
+float WeaponAwp::PRECISION = 0;
+float WeaponAwp::MAX_RANGE = 0;
 
 
-void WeaponAwp::init(int damage, float price, int bullets, int rate_of_fire) {
+void WeaponAwp::init(int damage, float price, int bullets, int rate_of_fire, float precision, float max_range) {
     if (initialized == false) {
         DAMAGE = damage;
         PRICE = price;
         INITIAL_BULLETS = bullets;
         RATE_OF_FIRE = rate_of_fire;
+        PRECISION = precision;
+        MAX_RANGE = max_range;
         initialized = true;
     }
 }
 //------------
 
-WeaponAwp::WeaponAwp(): FireWeapon(DAMAGE, PRICE, INITIAL_BULLETS, RATE_OF_FIRE) {}
+WeaponAwp::WeaponAwp(): FireWeapon(DAMAGE, PRICE, INITIAL_BULLETS, RATE_OF_FIRE, PRECISION, MAX_RANGE) {}
 
 Weapon WeaponAwp::getWeaponType() const { return Weapon::Awp; }
 

--- a/server/src/weapon/weapon_glock.cpp
+++ b/server/src/weapon/weapon_glock.cpp
@@ -6,19 +6,23 @@ bool WeaponGlock::initialized = false;
 int WeaponGlock::DAMAGE = 0;
 int WeaponGlock::INITIAL_BULLETS = 0;
 int WeaponGlock::RATE_OF_FIRE = 0;
+float WeaponGlock::PRECISION = 0;
+float WeaponGlock::MAX_RANGE = 0;
 
 
-void WeaponGlock::init(int damage, int bullets, int rate_of_fire) {
+void WeaponGlock::init(int damage, int bullets, int rate_of_fire, float precision, float max_range) {
     if (initialized == false) {
         DAMAGE = damage;
         INITIAL_BULLETS = bullets;
         RATE_OF_FIRE = rate_of_fire;
+        PRECISION = precision;
+        MAX_RANGE = max_range;
         initialized = true;
     }
 }
 //------------
 
-WeaponGlock::WeaponGlock(): FireWeapon(DAMAGE, 0, INITIAL_BULLETS, RATE_OF_FIRE) {}
+WeaponGlock::WeaponGlock(): FireWeapon(DAMAGE, 0, INITIAL_BULLETS, RATE_OF_FIRE, PRECISION, MAX_RANGE) {}
 
 Weapon WeaponGlock::getWeaponType() const { return Weapon::Glock; }
 

--- a/server/src/weapon/weapon_m3.cpp
+++ b/server/src/weapon/weapon_m3.cpp
@@ -9,20 +9,24 @@ int WeaponM3::DAMAGE = 0;
 float WeaponM3::PRICE = 0;
 int WeaponM3::INITIAL_BULLETS = 0;
 int WeaponM3::RATE_OF_FIRE = 0;
+float WeaponM3::PRECISION = 0;
+float WeaponM3::MAX_RANGE = 0;
 
 
-void WeaponM3::init(int damage, float price, int bullets, int rate_of_fire) {
+void WeaponM3::init(int damage, float price, int bullets, int rate_of_fire, float precision, float max_range) {
     if (initialized == false) {
         DAMAGE = damage;
         PRICE = price;
         INITIAL_BULLETS = bullets;
         RATE_OF_FIRE = rate_of_fire;
+        PRECISION = precision;
+        MAX_RANGE = max_range;
         initialized = true;
     }
 }
 //------------
 
-WeaponM3::WeaponM3(): FireWeapon(DAMAGE, PRICE, INITIAL_BULLETS, RATE_OF_FIRE) {}
+WeaponM3::WeaponM3(): FireWeapon(DAMAGE, PRICE, INITIAL_BULLETS, RATE_OF_FIRE, PRECISION, MAX_RANGE) {}
 
 Weapon WeaponM3::getWeaponType() const { return Weapon::M3; }
 

--- a/server/src/weapon/weapon_m3.cpp
+++ b/server/src/weapon/weapon_m3.cpp
@@ -39,7 +39,7 @@ std::vector<Projectile> WeaponM3::shoot(float posX, float posY, float dirX, floa
     bullets--;
 
     std::vector<Projectile> projectiles;
-    const int numPellets = 3;
+    const int numPellets = 5;
     const float spreadAngle = 0.15f;
 
     for (int i = 0; i < numPellets; ++i) {

--- a/server/src/yaml_config.cpp
+++ b/server/src/yaml_config.cpp
@@ -34,6 +34,8 @@ YamlConfig::WeaponData YamlConfig::getWeaponData(const std::string& weaponName) 
     data.bullets = node["bullets"] ? node["bullets"].as<int>() : 0;
     data.price = node["price"] ? node["price"].as<int>() : 0;
     data.rateOfFire = node["rate_of_fire"] ? node["rate_of_fire"].as<int>() : 0;
+    data.precision = node["precision"] ? node["precision"].as<float>() : 0;
+    data.maxRange = node["max_range"] ? node["max_range"].as<float>() : 0;
     return data;
 }
 


### PR DESCRIPTION
Se solucionaron los siguientes bugs: 
- Las 3 balas en la rafaga de la Ak47 salian con la misma posición por lo que se renderizaban una encima de la otra 
- Nunca se le pasaba al cliente las balas desactivadas por lo que no desaparecían al chocar con una pared
- No se mostraba la bala cuando la trayectoria intersectaba con la de un jugador

Se agregaron las funcionalidades: 
- Validación para evitar el friendly fire
- Modificación disparo de M3, 5 perdigones en lugar de 3
- Precision para las armas: Ahora se usa random y cada disparo cuando impacta con el jugador aleatoriamente puede fallar 
